### PR TITLE
Fix/artifacts names version

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -7,7 +7,7 @@
     <version>${revision}</version>
   </parent>
 
-  <artifactId>cli-client-library</artifactId>
+  <artifactId>cli-command-library</artifactId>
 
   <dependencies>
     <dependency>
@@ -27,6 +27,6 @@
     </dependency>
   </dependencies>
 
-  <name>cli-client-library</name>
+  <name>cli-command-library</name>
   <packaging>jar</packaging>
 </project>

--- a/lib/src/main/java/cli/ANSIEscapeCode.java
+++ b/lib/src/main/java/cli/ANSIEscapeCode.java
@@ -3,16 +3,32 @@ package cli;
 public enum ANSIEscapeCode {
 
 	
-	CLEAR(0), BLACK(30), RED(31), GREEN(32), YELLOW(33), BLUE(34), MAGENTA(35), CYAN(36), WHITE(37);
+	CLEAR(0),
+	BLACK(30),
+	RED(31),
+	GREEN(32),
+	YELLOW(33),
+	BLUE(34),
+	MAGENTA(35),
+	CYAN(36),
+	WHITE(37),
+	BRIGHT_BLUE(34, true),
+	BRIGHT_GREEN(32, true);
 	
 	private final int code;
-	
+	private boolean bright = false;
+
 	/**
 	 * Builds an escape code object
 	 * @param code Internal code representation
 	 */
 	private ANSIEscapeCode(int code) {
 		this.code = code;
+	}
+
+	private ANSIEscapeCode(int code, Boolean bright) {
+		this(code);
+		this.bright = bright;
 	}
 	
 	/**
@@ -22,6 +38,7 @@ public enum ANSIEscapeCode {
 	private String getCode() {
 		return Integer.toString(this.code);
 	}
+	private Boolean isBright() { return this.bright; }
 	
 	/**
 	 * Returns a string 'painted' in the specified color.
@@ -30,6 +47,6 @@ public enum ANSIEscapeCode {
 	 * @return Painted string
 	 */
 	public static String paint(String s, ANSIEscapeCode code) {
-		return (char)27 + "[" + code.getCode() + "m" + s + (char)27 + "[" + WHITE.getCode() + "m"; 
+		return (char)27 + "[" + code.getCode() + (code.isBright() ? ";1" : "") + "m" + s + (char)27 + "[0m";
 	}
 }

--- a/lib/src/main/java/cli/EntryPoint.java
+++ b/lib/src/main/java/cli/EntryPoint.java
@@ -236,7 +236,7 @@ class EntryPoint {
 		Field[] fields = command.getClass().getDeclaredFields();
 		Map<String, Method> methodsMap = new HashMap<>();
 		Method optionalArgsMethod = null;
-		for (Field field: fields) {			
+		for (Field field: fields) {
 			Method method = lookForSetter(field, methods);
 			if (field.isAnnotationPresent(Parameter.class)) {
 				Parameter parameter = field.getAnnotation(Parameter.class);
@@ -264,7 +264,7 @@ class EntryPoint {
 		//	present, it is assumed to be true
 		
 		for (Option option: commandLine.getOptions()) {
-			Method method = methodsMap.get(option.getArgName());
+			Method method = methodsMap.get(option.getOpt());
 			if (method == null) {
 				method = methodsMap.get(option.getLongOpt());
 			}

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,7 +25,7 @@
   <dependencies>
     <dependency>
       <groupId>cli-library</groupId>
-      <artifactId>cli-client-library</artifactId>
+      <artifactId>cli-command-library</artifactId>
       <version>${revision}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>pom</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>1.4-SNAPSHOT</revision>
+    <revision>1.5-SNAPSHOT</revision>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>pom</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>1.5-SNAPSHOT</revision>
+    <revision>1.6</revision>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Version 1.6
Fixes:
- Artifacts names and versions to make it coherent
- A bug that prevented to use parameters that only had a short name
- Added some ANSI escape codes